### PR TITLE
Fix blank Mermaid diagram in harness flowchart

### DIFF
--- a/content/geofencing-in-the-ai-era.mdx
+++ b/content/geofencing-in-the-ai-era.mdx
@@ -134,7 +134,8 @@ flowchart TB
   prompt --> classifier
   classifier --> model
   model --> policy
-  policy -->|allowed| sandbox --> tools
+  policy -->|allowed| sandbox
+  sandbox --> tools
   policy -->|blocked| audit
   tools --> audit
 ```

--- a/content/geofencing-in-the-ai-era.mdx
+++ b/content/geofencing-in-the-ai-era.mdx
@@ -247,29 +247,13 @@ that means:
 this is less satisfying than a clean country block. it is also closer to reality.
 
 ## the missing primitive: capability provenance
-current ai infrastructure mostly tracks access.
+most ai infrastructure still logs access the way a normal api does: account id, key id, region, timestamp, maybe request metadata. that is enough to answer billing questions and basic abuse detection. it is not enough to answer where a capability went after inference.
 
-who called the api? from which account? from which region? at what time?
+what you actually need is a record of the output itself and what happened next. which model version produced it, under what policy, with which tools enabled. whether it was written to memory, exported to a file, fed into a fine-tune job, copied into another prompt, or surfaced through a workflow other users can hit. without that, a geofence at the gateway tells you someone in the allowed region made a call. it does not tell you the call became a persistent artifact somewhere else.
 
-that is useful, but thin.
+this is closer to supply chain security than to classic access control. in production software, you stopped assuming dependencies were fine because they passed a download check. you started asking where binaries came from, who signed them, what they could touch at runtime, and what else they pulled in. ai systems need the same habit applied to model outputs, not just model weights.
 
-we need to track capability flow.
-
-which model produced this output? what policy applied? what tools were available? was the output stored? was it used for training? did it enter another model? did it become part of a workflow exposed to other users?
-
-this starts to look less like geofencing and more like supply chain security.
-
-software learned this the hard way. you cannot secure production by trusting that every dependency is fine. you need provenance, signing, dependency tracking, review, permissions, and runtime monitoring.
-
-ai needs the same shift.
-
-not just model access.
-
-model lineage.
-
-not just user geography.
-
-capability geography.
+the useful distinction is between access geography and capability geography. access geography is where the request originated. capability geography is where the behavior can still be exercised after the response leaves the model. policy and engineering have to track the second one, or geofencing stays a login-screen fiction.
 
 ## what a real ai geofence might look like
 a more realistic stack would have layers.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -145,9 +145,8 @@ code[data-line-numbers-max-digits="3"]>[data-line]::before {
   width: 3rem;
 }
 
-pre.mermaid {
-  @apply my-8 overflow-hidden rounded-lg bg-muted/40 text-transparent;
-  min-height: 8rem;
+pre.mermaid.mermaid-error {
+  @apply my-8 overflow-x-auto rounded-lg border border-destructive/40 bg-muted/20 p-4 text-sm text-foreground;
 }
 
 .mermaid-diagram {
@@ -156,4 +155,9 @@ pre.mermaid {
 
 .mermaid-diagram svg {
   @apply h-auto max-w-full;
+  color-scheme: light;
+}
+
+.dark .mermaid-diagram svg {
+  color-scheme: dark;
 }

--- a/src/components/mermaid-renderer.tsx
+++ b/src/components/mermaid-renderer.tsx
@@ -23,11 +23,12 @@ async function renderDiagrams(theme: string | undefined) {
     try {
       const { svg } = await mermaid.render(id, code);
       const wrapper = document.createElement("div");
-      wrapper.className = "mermaid-diagram";
+      wrapper.className = "mermaid-diagram not-prose";
       wrapper.innerHTML = svg;
       node.replaceWith(wrapper);
     } catch (error) {
       console.error("Mermaid render failed:", error);
+      node.classList.add("mermaid-error");
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix invalid chained edge syntax in the harness flowchart that caused Mermaid render to fail silently
- Remove empty gray placeholder styling on failed renders
- Add `not-prose` wrapper so typography styles do not interfere with SVG output
- Rewrite the capability provenance section with fuller technical prose (less fragment-style)

## Test plan
- [ ] Open `/blog/geofencing-in-the-ai-era` and confirm the harness diagram (section 4) renders as a vertical flowchart, not a blank box
- [ ] Confirm all 6 diagrams render correctly in light and dark mode
- [ ] Read the capability provenance section for tone and clarity