### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Next.js 14 (App Router) personal portfolio + MDX blog, deployed to Cloudflare Pages
+via `@cloudflare/next-on-pages`. Node 22 and `npm` (there is a `package-lock.json`).
+
+### Running / testing / building
+- Dev server: `npm run dev` (http://localhost:3000). Standard scripts live in `package.json`.
+- Lint: `npm run lint`. Build: `npm run build`. Both pass; the two `<img>`/alt-text warnings in
+  `src/components/mdx.tsx` are pre-existing and non-blocking.
+- Cloudflare build (`npm run pages:build`) is only needed for deploy validation, not local dev.
+
+### Environment / secrets (non-obvious)
+- Local dev needs a `.env.local` (gitignored; not created by the update script). See `.env.example`
+  for the full list.
+- The public site (home `/`, `/blog`, `/blog/[slug]`) renders with **no** secrets.
+- The admin portal (`/admin`) is gated by `ADMIN_PASSWORD`. Set it in `.env.local` to log in and
+  exercise content management locally (login POSTs to `/api/admin/auth/login`, sets an
+  `admin_session` cookie, verified via `/api/admin/auth/verify`).
+- Newsletter (`/test-newsletter`, `/api/admin/plunk/*`) needs real Plunk keys (`PLUNK_SECRET_KEY`,
+  `NEXT_PUBLIC_PLUNK_PUBLIC_KEY`); AI content generation (`/api/admin/llm/generate`) needs
+  `LLM_API_KEY`/`LLM_BASE_URL`/`LLM_MODEL_ID`. These call external services and are optional locally.
+
+### Content
+- Blog posts are `content/*.mdx` with YAML frontmatter; see `BLOG_STANDARDS.md` for the frontmatter
+  and the strict allowed-tags rule. Adding an `.mdx` file adds a route under `/blog/[slug]`.
+- All `/api/admin/*` routes use the Edge runtime (`export const runtime = 'edge'`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for this Next.js 14 portfolio + MDX blog (deployed to Cloudflare Pages). No application code was changed — this only adds durable environment documentation for future agents. Verified the full local dev flow end-to-end: install, lint, build, dev server, and an admin-login "hello world" task.

The startup dependency-refresh step is configured separately via the Cloud Agent update script (`npm ci`), not in the repo.

## Changes

- `AGENTS.md` (new): adds a `## Cursor Cloud specific instructions` section covering:
  - Node 22 / `npm` (there is a `package-lock.json`), and where standard scripts live.
  - The non-obvious secrets story: the public site renders with no secrets; `/admin` is gated by `ADMIN_PASSWORD`; newsletter (Plunk) and AI generation (LLM) need real external keys and are optional locally. `.env.local` is gitignored and not created by the update script.
  - Content model: `content/*.mdx` drives `/blog/[slug]`; see `BLOG_STANDARDS.md`. All `/api/admin/*` routes use the Edge runtime.

## Test plan

- `npm ci` — installs 781 packages, exit 0.
- `npm run lint` — passes (only 2 pre-existing `<img>`/alt-text warnings in `src/components/mdx.tsx`).
- `npm run build` — compiles successfully, generates all 28 pages/routes.
- `npm run dev` — server ready on http://localhost:3000.
- Endpoint checks: `/`, `/blog`, `/blog/intro`, `/admin` all return `200`.
- Admin auth flow: wrong password -> `401`; correct password (`localdev` via `.env.local`) -> `200` + `admin_session` cookie; `/api/admin/auth/verify` with cookie -> `{"authenticated":true}`.
- GUI walkthrough: home, blog list, a blog post, admin login, and the logged-in content-management dashboard all render correctly.

## Risk / follow-ups

- Low risk: docs-only change, no runtime code touched.
- Newsletter/LLM features can't be exercised locally without real Plunk/LLM API keys; not required for core site or admin content management.
- `npm ci` reports npm-audit vulnerabilities (incl. a Next.js 14.2.4 advisory) — pre-existing, out of scope for env setup.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7d025b4-5ff0-4b3d-a9c0-7cf49895c25c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7d025b4-5ff0-4b3d-a9c0-7cf49895c25c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

