### PR TITLE
docs: persist Cloudflare preview link rule for Cloud Agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# Agent instructions for siddhant.site
+
+## Cloudflare Pages preview links (required)
+
+Whenever you push changes that trigger a Cloudflare Pages deploy, **always include the direct preview URL(s) in your response** so Siddhant can open them from chat without hunting in GitHub or the Cloudflare dashboard.
+
+The dashboard build link is not enough — send the clickable `*.pages.dev` preview.
+
+### How to get preview URLs
+
+After pushing to a branch with an open PR:
+
+1. **GitHub PR comment** (fastest): Cloudflare's bot posts Preview URL and Branch Preview URL.
+   ```bash
+   gh pr view <number> --repo sdntsng/siddhant.site --comments
+   ```
+2. **Commit status**:
+   ```bash
+   gh api repos/sdntsng/siddhant.site/commits/<sha>/status --jq '.statuses[] | {context, target_url, description}'
+   ```
+
+### URL patterns
+
+- **Commit preview**: `https://<deployment-id>.siddhant-site.pages.dev`
+- **Branch preview**: `https://<branch-slug>.siddhant-site.pages.dev` (slashes → hyphens, lowercase)
+
+When sharing previews for UI work, include:
+
+- Branch preview URL (stable for the branch)
+- Direct paths to the relevant pages (e.g. `/prototype/a-refine`)
+- Production `/` for side-by-side comparison when useful
+
+## Homepage prototype gallery (in progress)
+
+Branch: `pr/homepage-prototypes-9fc4` (draft PR #26). **Live `/` is unchanged** until explicitly approved.
+
+| Route | What it explores |
+|-------|------------------|
+| `/prototype` | Overview hub + links |
+| `/prototype/a-refine` | Subtle: Source Serif/Sans, no BlurFade, same layout |
+| `/prototype/b-chrome` | Moderate: stone palette, mono labels, top bar (dock replacement preview) |
+| `/prototype/c-rhythm` | Structural: flat work timeline, compact education, inline interests, featured project |
+
+Workflow:
+
+1. User compares variants vs live `/` in tabs and gives mix-and-match feedback.
+2. Run `/impeccable init` with the chosen direction.
+3. Apply **only chosen pieces** to the production homepage (`home-page-content.tsx`).
+
+Impeccable is installed (`.cursor/skills/impeccable/`) but `/impeccable init`, `PRODUCT.md`, and `DESIGN.md` stay deferred until a direction is picked.
+
+Do not merge prototype changes to `/` without explicit user approval.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` so every Cursor Cloud Agent session on this repo remembers to include **direct Cloudflare Pages preview URLs** (`*.pages.dev`) whenever work is pushed and deployed — not just dashboard links or "check the PR" notes.

Also captures the in-progress homepage prototype gallery context (branch, routes, workflow) so future agents don't lose state between sessions.

## Changes

- **`AGENTS.md`** (new)
  - Required: share clickable Cloudflare preview URLs after deploys
  - How to fetch URLs via `gh pr view --comments` or commit status API
  - URL patterns for commit vs branch previews
  - Prototype gallery routes, branch name, and "nothing to `/` without approval" rule

## Test plan

- [x] File renders as valid markdown
- [ ] Merge to `main` — subsequent Cloud Agent runs should load `AGENTS.md` automatically
- [ ] Next deploy: agent response includes branch preview URL + relevant paths

## Risk / follow-ups

- Low risk — docs only
- Prototype work remains on `pr/homepage-prototypes-9fc4` (PR #26, currently closed draft); reopen or new PR when ready to continue review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-519a4740-0e69-4fd0-ab10-496d27966d93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-519a4740-0e69-4fd0-ab10-496d27966d93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

